### PR TITLE
Fix: Serialize TextMetrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Import `typometer`.
 import { typometer } from "typometer"
 ```
 
-Invoke it asynchronously with a string and access [`TextMetrics`](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics) in return.
+Invoke it asynchronously with a string and access serialized [`TextMetrics`](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics) in return.
 
 ```typescript
 const metrics = await typometer("With impressions chosen from another time.")
@@ -68,7 +68,7 @@ const metrics = await typometer("With impressions chosen from another time.")
 // }
 ```
 
-Given an array of strings instead, `typometer` will return an array of [`TextMetrics`](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics).
+Given an array of strings instead, `typometer` will return an array of serialized [`TextMetrics`](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics).
 
 ```typescript
 const metrics = await typometer([

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
 import { isArray } from "./guards"
 import { measureText } from "./measure-text"
-import { Font } from "./types"
+import { Font, SerializedTextMetrics } from "./types"
 
 /**.
  * Measure text using the Canvas API.
  *
  * @param text - The text to measure, as a single string or an array of different strings.
  * @param [font] - The font properties to set.
- * @returns A promise fulfilling into text metrics.
+ * @returns A promise fulfilling into serialized text metrics.
  *
  * @example
  *
@@ -17,16 +17,19 @@ import { Font } from "./types"
  * // metrics: TextMetrics
  * ```
  */
-export async function typometer(text: string, font?: Font): Promise<TextMetrics>
+export async function typometer(
+  text: string,
+  font?: Font
+): Promise<SerializedTextMetrics>
 export async function typometer(
   text: string[],
   font?: Font
-): Promise<TextMetrics[]>
+): Promise<SerializedTextMetrics[]>
 export async function typometer(
   text: string[] | string,
   font?: Font
-): Promise<TextMetrics | TextMetrics[]> {
-  let metrics: TextMetrics | TextMetrics[]
+): Promise<SerializedTextMetrics | SerializedTextMetrics[]> {
+  let metrics: SerializedTextMetrics | SerializedTextMetrics[]
 
   if (isArray(text)) {
     metrics = []

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,4 +46,4 @@ export async function typometer(
 
 export { typometer as measure }
 
-export type { Font, FontProperties } from "./types"
+export type { Font, FontProperties, SerializedTextMetrics } from "./types"

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,8 @@ export type PlainFunction<P = any, R = any> = (...args: P[]) => R
 
 export type Mutable<T> = { -readonly [P in keyof T]: T[P] }
 
+export type SerializedTextMetrics = Mutable<TextMetrics>
+
 export type Font = FontProperties | Pick<CSSStyleDeclaration, "font"> | string
 
 export interface FontProperties {

--- a/src/utils/serialize-text-metrics.ts
+++ b/src/utils/serialize-text-metrics.ts
@@ -1,5 +1,5 @@
 import { isNumber } from "../guards"
-import { Mutable } from "../types"
+import { SerializedTextMetrics } from "../types"
 
 /**
  * Serialize a `TextMetrics` object into a plain one.
@@ -7,7 +7,7 @@ import { Mutable } from "../types"
  * @param metrics - The `TextMetrics` object to serialize.
  */
 export function serializeTextMetrics(metrics: TextMetrics) {
-  const plainMetrics = {} as Mutable<TextMetrics>
+  const plainMetrics = {} as SerializedTextMetrics
 
   for (const property of Object.getOwnPropertyNames(
     Object.getPrototypeOf(metrics)


### PR DESCRIPTION
Fix inconsistent result types by always returning serialized `TextMetrics`.